### PR TITLE
move hashing struct to kiss_icp namespace

### DIFF
--- a/cpp/kiss_icp/core/VoxelUtils.hpp
+++ b/cpp/kiss_icp/core/VoxelUtils.hpp
@@ -43,11 +43,9 @@ inline Eigen::Vector3d VoxelCenter(const Voxel &voxel, const double voxel_size) 
            Eigen::Vector3d::Constant(voxel_size * 0.5);
 }
 
-/// Voxelize a point cloud keeping the original coordinates
+// Voxelize a point cloud keeping the original coordinates
 std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> &frame,
                                              const double voxel_size);
-
-}  // namespace kiss_icp
 
 struct VoxelHash {
     std::size_t operator()(const kiss_icp::Voxel &voxel) const {
@@ -55,3 +53,4 @@ struct VoxelHash {
         return (vec[0] * 73856093 ^ vec[1] * 19349669 ^ vec[2] * 83492791);
     }
 };
+}  // namespace kiss_icp


### PR DESCRIPTION
ODR violations happen when using kiss-icp alongside other libraries which also have their own has function for the Eigen::Vector3i type. Moving the hash function inside the kiss_icp namespace fixes it for now.